### PR TITLE
Add an extra guard to jquery detection

### DIFF
--- a/src/utils/commands/index.js
+++ b/src/utils/commands/index.js
@@ -58,7 +58,10 @@ function getSubject(testSubject) {
 }
 
 function isJQuery(subject) {
-  return subject && subject.constructor.name === 'jQuery'
+  return subject && (
+    subject.constructor.name === 'jQuery' ||
+    subject.constructor.prototype.jquery
+  );
 }
 
 function isHtml(subject) {


### PR DESCRIPTION
First of all, thank you for making this great library 👍 

In my cypress env, this library can't detect jQuery elements on calling `toMatchSnapshot`.
So everything breaks on calling `toMatchSnapshot` (`toMatchImageSnapshot` works great!)
because my jQuery is too minified, the constructor name is just `r`, not `jQuery`.
Fortunately, we can check the jQuery elements by checking the presence of `.prototype.jquery`.
So I just add an extra condition 😃 

Thank you @meinaart 