### PR TITLE
Fixes a bug where undefined path would throw error

### DIFF
--- a/cypress/cypress/integration/toMatchImageSnapshot.spec.js
+++ b/cypress/cypress/integration/toMatchImageSnapshot.spec.js
@@ -30,4 +30,14 @@
           });
         });
     });
+
+    it('toMatchImageSnapshot - no base snapshot', () => {
+      cy.visit('/static/stub.html')
+        .then(() => {
+          cy.wait(1000); // seems a bug with webfonts that requires this
+          cy.document().toMatchImageSnapshot({
+            threshold: 0.1
+          });
+        });
+    });
   });

--- a/src/utils/image/getImageData.js
+++ b/src/utils/image/getImageData.js
@@ -5,7 +5,7 @@ function getImageData(props, devicePixelRatio = 1) {
     height: props.height || props.dimensions && props.dimensions.height,
     path: props.path,
     devicePixelRatio,
-    relativePath: path.relative(process.cwd(), props.path),
+    relativePath: (props.path) ? path.relative(process.cwd(), props.path) : '',
     width: props.width || props.dimensions && props.dimensions.width,
   };
 }


### PR DESCRIPTION
If the path was undefined (no base image) the plugin would throw a error, breaking behavior like `autoPassNewSnapshots`.