### PR TITLE
Clear image files cache when restarting tests

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -13,13 +13,13 @@ function closeSnapshotModal() {
 
   // Bug: `cy.readFile` only works first time, as a fix I wrap it in a cached `Cypress.Promise`.
   // @TODO: file a bug report about this.
-  const __readFileCache__ = {};
   function readFile(fullPath, encoding = 'base64', options = { log: false }) {
-    if (!__readFileCache__[encoding]) {
-      __readFileCache__[encoding] = {};
+    if (!Cypress.__readFileCache__) Cypress.__readFileCache__ = {};
+    if (!Cypress.__readFileCache__[encoding]) {
+      Cypress.__readFileCache__[encoding] = {};
     }
 
-    const cache = __readFileCache__[encoding];
+    const cache = Cypress.__readFileCache__[encoding];
     if (!cache[fullPath]) {
       cache[fullPath] = new Cypress.Promise((resolve) => {
         cy.readFile(fullPath, encoding, options).then(resolve);

--- a/commands.js
+++ b/commands.js
@@ -43,8 +43,15 @@ function initCommands() {
     }
   }
 
-  // Close snapshot modal before all test restart
-  Cypress.on('window:before:unload', closeSnapshotModal);
+  function clearFileCache() {
+    Cypress.__readFileCache__ = {};
+  }
+
+  // Close snapshot modal and reset image files cache before all test restart
+  Cypress.on('window:before:unload', () => {
+    closeSnapshotModal()
+    clearFileCache()
+  });
 
   // Clean up unused snapshots
   after(() => {


### PR DESCRIPTION
Hi.

Because cy.readFile seems bugged, image files content is cached.
But the current implementation is problematic because the cache is not cleared unless the browser is closed.
So when restarting tests on the same browser instance the images shown in the popup are different from the actual files which might have changed due to tests / code modification.

This PR clear the cache when the tests restart (cy.readFile is working correctly after tests restart)