### PR TITLE
chore: update readme to reflect proper thresholdTypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ You can pass the following options to `toMatchImageSnapshot` to override default
 {
   "createDiffImage": true,       // Should a "diff image" be created, can be disabled for performance
   "threshold": 0.01,             // Amount in pixels or percentage before snapshot image is invalid
-  "thresholdType": "percent",    // Can be either "pixels" or "percent"
+  "thresholdType": "percent",    // Can be either "pixel" or "percent"
 }
 ```
 


### PR DESCRIPTION
### Purpose
Readme states `pixels` is a valid option when it is really `pixel`

### Changes
Updated typo