### PR TITLE
feat: Adds ability to change background-blend-mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Add the configuration below to your `cypress.json` file to make changes to the d
     "serverHost": "localhost",       // Hostname for "update snapshot server"
     "serverPort": 2121,              // Port number for  "update snapshot server"
     "updateSnapshots": false,        // Automatically update snapshots, useful if you have lots of changes
+    "backgroundBlend": "difference", // background-blend-mode for diff image, useful to switch to "overlay" 
   }
 }
 ```

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -186,9 +186,6 @@ a[href^="#cypress-plugin-snapshot-"]:before {
 .snapshot-image--diff:hover {
   opacity: 1;
 }
-.snapshot-image--diff .snapshot-image__wrapper {
-  background-blend-mode: difference;
-}
 
 .snapshot-image__title {
   color: #555;

--- a/src/config.js
+++ b/src/config.js
@@ -47,6 +47,7 @@ const DEFAULT_CONFIG = Object.freeze({
   serverPort: 2121,
   token: createToken(),
   updateSnapshots: false,
+  backgroundBlend: 'difference',
   name: '',
 });
 

--- a/src/ui.js
+++ b/src/ui.js
@@ -39,6 +39,12 @@ function initUi() {
     $head.append(`<style>${content}</style>`);
   });
 
+  $head.append(`<style>
+  .snapshot-image--diff .snapshot-image__wrapper {
+    background-blend-mode: ${config.backgroundBlend ? config.backgroundBlend : 'difference'}
+  }
+  </style>`);
+
   readFile(PATH_BASE64_JS).then((content) => {
     $head.append(`<script>${content}</script>`);
   });


### PR DESCRIPTION
The default background-blend-mode when displaying diff images on hover of `difference` isn't always the most useful. This allows for user-defined blend mode (in config) to change to something more like `overlay`