### PR TITLE
Publish the `types` folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "assets",
     "docs",
     "LICENSE",
-    "src"
+    "src",
+    "types"
   ],
   "engines": {
     "node": ">=8.2.1"


### PR DESCRIPTION
Although #36 added TypeScript types to this project, these types are not getting published to NPM. This PR simply adds the `types` folder to package.json so these types will get published