### PR TITLE
Removes empty folders created by snapshots

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -9,6 +9,7 @@ const commands = require('./src/commands/index');
 const cleanUpSnapshots = require('./src/utils/commands/cleanupSnapshots');
 const getConfig = require('./src/utils/commands/getConfig');
 const { NO_LOG } = require('./src/constants');
+const { CLEANUP_FOLDERS } = require('./src/tasks/taskNames');
 
 function addCommand(commandName, method) {
   Cypress.Commands.add(commandName, {
@@ -56,6 +57,7 @@ function initCommands() {
   // Clean up unused snapshots
   after(() => {
     cleanUpSnapshots();
+    cy.task(CLEANUP_FOLDERS, Cypress.config('screenshotsFolder'), NO_LOG).then(console.log);
   });
 
   // Add commands

--- a/src/tasks/cleanupFolders.js
+++ b/src/tasks/cleanupFolders.js
@@ -1,0 +1,8 @@
+const { removeEmptyFoldersRecursively } = require('../utils/File');
+
+// Removes empty folders created by snapshots
+function cleanup(folderPath) {
+	return removeEmptyFoldersRecursively(folderPath);
+}
+
+module.exports = cleanup;

--- a/src/tasks/index.js
+++ b/src/tasks/index.js
@@ -1,14 +1,17 @@
 const {
   GET_FILE,
   MATCH_IMAGE,
-  MATCH_TEXT
+  MATCH_TEXT,
+  CLEANUP_FOLDERS
 } = require('./taskNames');
 const getFile = require('./getFile');
 const matchImageSnapshot = require('./matchImageSnapshot');
 const matchTextSnapshot = require('./matchTextSnapshot');
+const cleanupFolders = require('./cleanupFolders');
 
 module.exports = {
   [GET_FILE]: getFile,
   [MATCH_IMAGE]: matchImageSnapshot,
   [MATCH_TEXT]: matchTextSnapshot,
+  [CLEANUP_FOLDERS]: cleanupFolders
 }

--- a/src/tasks/taskNames.js
+++ b/src/tasks/taskNames.js
@@ -2,4 +2,5 @@ module.exports = {
   GET_FILE: 'cypress-plugin-snapshot:getFile',
   MATCH_IMAGE: 'cypress-plugin-snapshot:matchImage',
   MATCH_TEXT: 'cypress-plugin-snapshot:matchText',
+  CLEANUP_FOLDERS: 'cypress-plugin-snapshot:cleanupFolders'
 };

--- a/src/utils/File.js
+++ b/src/utils/File.js
@@ -1,0 +1,80 @@
+/** @module File */
+
+const fs = require('fs');
+const path = require('path');
+
+
+/**
+ * Checks if the path exists.
+ * @param {string} path - File/directory path to check.
+ * @return {boolean} Whether or not the path exists.
+*/
+function pathExists(path) {
+	try {
+		return fs.existsSync(path);
+	} catch (err) {
+		throw new Error('Unable to determine if file exists: ' + err);
+	}
+}
+
+/**
+ * Checks if the path is a directory.
+ * @param {string} dirPath - Path to check.
+*/
+function isDir(dirPath) {
+	try {
+		if (pathExists(dirPath)) {
+			try {
+				var stat = fs.lstatSync(dirPath);
+				return stat.isDirectory();
+			} catch (e) {
+				return false;
+			}
+		}
+		return !path.extname(dirPath);
+	} catch (err) {
+		throw new Error('Unable to determine if directory: ' + err);
+	}
+}
+
+/**
+ * Recursively empties directory.
+ * @param {string} folder - Path of folder to empty.
+*/
+function removeEmptyFoldersRecursively(folder) {
+	function cleanFolderRecursively(folder) {
+		if (isDir(folder)) {
+
+			var files = fs.readdirSync(folder);
+
+			if (files.length > 0) {
+				files.forEach(function (file) {
+					cleanFolderRecursively(path.join(folder, file));
+				});
+
+				// re-evaluate files; after deleting subfolder parent folder might be empty
+				files = fs.readdirSync(folder);
+			}
+
+			if (files.length == 0) {
+				folders.push(folder);
+				fs.rmdirSync(folder);
+				return;
+			}
+		}
+	}
+
+	try {
+		var folders = []; // Folders that were removed
+		if (pathExists(folder)) {
+			cleanFolderRecursively(folder);
+		}
+		return folders;
+	} catch(err) {
+		console.err(err);
+	}	
+}
+
+module.exports = {
+	removeEmptyFoldersRecursively
+}

--- a/src/utils/File.js
+++ b/src/utils/File.js
@@ -6,15 +6,15 @@ const path = require('path');
 
 /**
  * Checks if the path exists.
- * @param {string} path - File/directory path to check.
+ * @param {string} pathToCheck - File/directory path to check.
  * @return {boolean} Whether or not the path exists.
 */
-function pathExists(path) {
-	try {
-		return fs.existsSync(path);
-	} catch (err) {
-		throw new Error('Unable to determine if file exists: ' + err);
-	}
+function pathExists(pathToCheck) {
+  try {
+    return fs.existsSync(pathToCheck);
+  } catch (err) {
+    throw new Error(`Unable to determine if file exists: ${err}`);
+  }
 }
 
 /**
@@ -22,59 +22,52 @@ function pathExists(path) {
  * @param {string} dirPath - Path to check.
 */
 function isDir(dirPath) {
-	try {
-		if (pathExists(dirPath)) {
-			try {
-				var stat = fs.lstatSync(dirPath);
-				return stat.isDirectory();
-			} catch (e) {
-				return false;
-			}
-		}
-		return !path.extname(dirPath);
-	} catch (err) {
-		throw new Error('Unable to determine if directory: ' + err);
-	}
+  try {
+    if (pathExists(dirPath)) {
+      try {
+        const stat = fs.lstatSync(dirPath);
+        return stat.isDirectory();
+      } catch (e) {
+        return false;
+      }
+    }
+    return !path.extname(dirPath);
+  } catch (err) {
+    throw new Error(`Unable to determine if directory: ${err}`);
+  }
 }
 
 /**
  * Recursively empties directory.
  * @param {string} folder - Path of folder to empty.
 */
-function removeEmptyFoldersRecursively(folder) {
-	function cleanFolderRecursively(folder) {
-		if (isDir(folder)) {
+function removeEmptyFoldersRecursively(folderToClean) {
+  function cleanFolderRecursively(folder) {
+    if (isDir(folder)) {
 
-			var files = fs.readdirSync(folder);
+      let files = fs.readdirSync(folder);
 
-			if (files.length > 0) {
-				files.forEach(function (file) {
-					cleanFolderRecursively(path.join(folder, file));
-				});
+      if (files.length > 0) {
+        files.forEach(function (file) {
+          cleanFolderRecursively(path.join(folder, file));
+        });
 
-				// re-evaluate files; after deleting subfolder parent folder might be empty
-				files = fs.readdirSync(folder);
-			}
+        // re-evaluate files; after deleting subfolder parent folder might be empty
+        files = fs.readdirSync(folder);
+      }
 
-			if (files.length == 0) {
-				folders.push(folder);
-				fs.rmdirSync(folder);
-				return;
-			}
-		}
-	}
+      if (files.length === 0) {
+        fs.rmdirSync(folder);
+      }
+    }
+  }
 
-	try {
-		var folders = []; // Folders that were removed
-		if (pathExists(folder)) {
-			cleanFolderRecursively(folder);
-		}
-		return folders;
-	} catch(err) {
-		console.err(err);
-	}	
+  if (pathExists(folderToClean)) {
+    cleanFolderRecursively(folderToClean);
+  }
+  return true;
 }
 
 module.exports = {
-	removeEmptyFoldersRecursively
-}
+  removeEmptyFoldersRecursively
+};


### PR DESCRIPTION
Moving snapshots to the __image_snapshots__ folder results in empty folders in the default Cypress snapshot folder - this cleans them up after the tests run.