### PR TITLE
feat: migrates `plugin.js` to be compatible with cypress 4.0.0

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -19,13 +19,12 @@ function initPlugin(on, globalConfig = {
   // That's why the config is stringified and parsed again in `src/utils/commands/getConfig.js#fixConfig`.
   globalConfig.env[CONFIG_KEY] = JSON.stringify(config);
 
-  on('before:browser:launch', (browser = {}, args) => {
+  on('before:browser:launch', (browser = {}, launchOptions) => {
     if (browser.name === 'chrome') {
-      args.push('--font-render-hinting=medium');
-      args.push('--enable-font-antialiasing');
-      args.push('--disable-gpu');
+      launchOptions.args.push('--font-render-hinting=medium');
+      launchOptions.args.push('--enable-font-antialiasing');
+      launchOptions.args.push('--disable-gpu');
     }
-    return args;
   });
 
   on('task', tasks);


### PR DESCRIPTION
The event `before:browser:launch` has changed. This fix will make it compatible with cypress 4.0.0. But will break previous versions of Cypress!

https://docs.cypress.io/guides/references/migration-guide.html#Plugin-Event-before-browser-launch

BREAKING CHANGE: Upgraded configuration will break previous versions of Cypress!