### PR TITLE
Add padding support to screenshots

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -10,6 +10,7 @@ const DEFAULT_SCREENSHOT_CONFIG = Object.freeze({
   blackout: [],
   capture: 'fullPage',
   clip: null,
+  padding: null,
   disableTimersAndAnimations: true,
   log: false,
   scale: false,


### PR DESCRIPTION
Cypress have added a padding option to their screenshots API which is really useful for capturing drop shadows around an element etc. I think this one line is all that's required to enable it in this plugin.