### PR TITLE
fix(base64): base64.min.js has been removed in js-base64@2.6.X

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4443,9 +4443,9 @@
       "integrity": "sha512-9IXdWudL61npZjvLuVe/ktHiA41iE8qFyLB+4VDTblEsWBzeg8WQTlktdUK4CdncUqtUgUg0bbOmTE2bKBKaBQ=="
     },
     "js-base64": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.1.tgz",
-      "integrity": "sha512-M7kLczedRMYX4L8Mdh4MzyAMM9O5osx+4FcOQuTvr3A9F2D9S5JXheN0ewNbrvK2UatkTRhL5ejGmGSjNMiZuw=="
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.1.tgz",
+      "integrity": "sha512-G5x2saUTupU9D/xBY9snJs3TxvwX8EkpLFiYlPpDt/VmMHOXprnSU1nxiTmFbijCX4BLF/cMRIfAcC5BiMYgFQ=="
     },
     "js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "fs-extra": "^7.0.1",
     "image-size": "^0.7.2",
     "jimp": "^0.10.3",
-    "js-base64": "^2.5.1",
+    "js-base64": "2.6.1",
     "lodash": "^4.17.13",
     "pixelmatch": "^4.0.2",
     "pngjs": "^3.3.3",

--- a/src/paths.js
+++ b/src/paths.js
@@ -1,5 +1,5 @@
 module.exports = {
-  PATH_BASE64_JS: 'js-base64/base64.min.js',
+  PATH_BASE64_JS: 'js-base64/base64.js',
   PATH_CSS: './assets/styles.css',
   PATH_DIFF_CSS: 'diff2html/dist/diff2html.css',
   PATH_DIFF_JS: 'diff2html/dist/diff2html.js',


### PR DESCRIPTION
Since js-base64@2.6.0, only the non-minified js is included in the modules, which breaks cypress-plugin-snapshots:

![Error](https://p119.p3.n0.cdn.getcloudapp.com/items/OAuBgBw2/Screenshot%202020-06-22%20at%2012.02.16.png?v=da5202e831cdb1ed2b0f81ad0b6d0c93)

