### PR TITLE
remove the need to sanitize files

### DIFF
--- a/src/utils/image/getSnapshotFilename.js
+++ b/src/utils/image/getSnapshotFilename.js
@@ -1,12 +1,10 @@
 const path = require('path');
-const sanitizeFilename = require('sanitize-filename');
 const { DIR_IMAGE_SNAPSHOTS } = require('../../constants');
 
 function getSnapshotFilename(testFile, snapshotTitle, type = '') {
   const dir = path.join(path.dirname(testFile), DIR_IMAGE_SNAPSHOTS);
   const fileType = type ? `.${type}` : '';
-  const filename = sanitizeFilename(`${snapshotTitle}${fileType}.png`);
-  return path.join(dir, filename);
+  return path.join(dir, `${snapshotTitle}${fileType}.png`);
 }
 
 module.exports = getSnapshotFilename;


### PR DESCRIPTION
I'm not sure why we need to "sanitize" files, all test are under a controlled environment and doesn't expose to any sort of threat. It seems to be doing more harm than good, e.g. with this kind of naming restriction I can't even assign files under different directories as the `/` char gets stripped. Also, another prime example is I see that in https://github.com/meinaart/cypress-plugin-snapshots/blob/89f0dca1a2feec0a0a4b02d7bf4e8b119f4e6a16/src/utils/getTestTitle.js#L2 the ` > ` separator also gets stripped, so I'm still wondering if we can remove this altogether?