### PR TITLE
fixup js-base64 proper

### DIFF
--- a/src/paths.js
+++ b/src/paths.js
@@ -1,5 +1,5 @@
 module.exports = {
-  PATH_BASE64_JS: 'js-base64/base64.min.js',
+  PATH_BASE64_JS: 'js-base64',
   PATH_CSS: './assets/styles.css',
   PATH_DIFF_CSS: 'diff2html/dist/diff2html.css',
   PATH_DIFF_JS: 'diff2html/dist/diff2html.js',


### PR DESCRIPTION
closes #125, closes #126 I think just keep it simple and use the path defined in main rather than hardcoding.

Have tested, and works.