### PR TITLE
fix(crypto): replace with rand-token dependency

### DIFF
--- a/__tests__/config.test.js
+++ b/__tests__/config.test.js
@@ -47,6 +47,6 @@ describe('config', () => {
   });
 
   it('createToken', () => {
-    expect(createToken()).toEqual(expect.stringMatching(/[a-z0-9]{128}/));
+    expect(createToken()).toEqual(expect.stringMatching(/[A-Za-z0-9]{128}/));
   });
 });

--- a/__tests__/config.test.js
+++ b/__tests__/config.test.js
@@ -1,4 +1,4 @@
-const { getImageConfig, getScreenshotConfig } = require('../src/config');
+const { getImageConfig, getScreenshotConfig, createToken } = require('../src/config');
 
 describe('config', () => {
   it('getImageConfig', () => {
@@ -44,5 +44,9 @@ describe('config', () => {
       scale: false,
       timeout: 30000,
     });
+  });
+
+  it('createToken', () => {
+    expect(createToken()).toEqual(expect.stringMatching(/[a-z0-9]{128}/));
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -5445,6 +5445,11 @@
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
     },
+    "rand-token": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rand-token/-/rand-token-1.0.1.tgz",
+      "integrity": "sha512-Zri5SfJmEzBJ3IexFdigvPSCamslJ7UjLkUn0tlgH7COJvaUr5V7FyUYgKifEMTw7gFO8ZLcWjcU+kq8akipzg=="
+    },
     "react-is": {
       "version": "16.9.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.9.0.tgz",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "pixelmatch": "^4.0.2",
     "pngjs": "^3.3.3",
     "prettier": "^1.16.4",
+    "rand-token": "^1.0.1",
     "rimraf": "^2.6.3",
     "sanitize-filename": "^1.6.1",
     "socket.io": "^2.2.0",

--- a/src/config.js
+++ b/src/config.js
@@ -127,6 +127,7 @@ module.exports = {
   CONFIG_KEY,
   DEFAULT_IMAGE_CONFIG,
   DEFAULT_SCREENSHOT_CONFIG,
+  createToken,
   getConfig,
   getImageConfig,
   getPrettierConfig,

--- a/src/config.js
+++ b/src/config.js
@@ -1,9 +1,9 @@
-const crypto = require('crypto');
+const randtoken = require('rand-token');
 const { merge, cloneDeep, clone } = require('lodash');
 const { TYPE_JSON } = require('./dataTypes');
 
 function createToken() {
-  return crypto.randomBytes(64).toString('hex');
+  return randtoken.generate(128);
 }
 
 const DEFAULT_SCREENSHOT_CONFIG = Object.freeze({


### PR DESCRIPTION
Fixes #143 

Remove the dependency on [crypto](https://nodejs.org/api/crypto.html) and replace functionality with [sehrope/node-rand-token](https://github.com/sehrope/node-rand-token).

### Background

I created a test in Jest to confirm that `createToken` works as expected.

However, when running Cypress, the `crypto` object has an `undefined` value on the `randomBytes` property. This is what causes the error described in #143 .

Because the test passes in Jest, I thought this may be due to `crypto` running in node but not in the browser. As a result, I attempted to use the `randomBytes` method from https://github.com/crypto-browserify. However, this returned an empty object for the `randomBytes` property in Cypress.

Finally, I decided to remove the dependency on `crypto` entirely and look for the best alternative that can perform the same functionality of generating a token.

### A note on Cypress 5 compatibility

This is only one step in achieving compatibility with Cypress 5. With this PR, Cypress gets past `createToken` but runs into another error as follows.

This looks similar in the sense that the error comes from a [node builtin](https://nodejs.org/api/util.html).

```
The following error originated from your test code, not from Cypress.

  > util.inherits is not a function

node_modules/assert/assert.js:164:1
  162 | 
  163 | // assert.AssertionError instanceof Error
> 164 | util.inherits(assert.AssertionError, Error);
      | ^
  165 | 
  166 | function truncate(s, n) {
  167 |   if (typeof s === 'string') {
```

### Node builtin support

Looking at https://github.com/cypress-io/cypress/pull/8273, it seems Cypress adds support for specific node builtins. Perhaps this is related, and investigating node builtin support could lead to a better solution.