### PR TITLE
add type for separator

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -21,7 +21,8 @@ declare namespace Cypress {
       createDiffImage: boolean,
       threshold: number,
       thresholdType: "percent" | "pixels",
-      name: string
+      name: string,
+      separator: string
     }> & Partial<ScreenshotDefaultsOptions>): Chainable<null>;
   }
 }


### PR DESCRIPTION
added it because there was no type for `separator`. 

related  https://github.com/meinaart/cypress-plugin-snapshots/pull/82