### PR TITLE
Improve screenshot options example

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,9 @@ For example:
 ```javascript
 cy.get('.element')
   .toMatchImageSnapshot({
-    clip: { x: 0, y: 0, width: 100, height: 100 },
+    screenshotConfig: {
+      clip: { x: 0, y: 0, width: 100, height: 100 }
+    }
   });
 ```
 


### PR DESCRIPTION
Created a quick change to fix the example of clip option to be used for screenshots.

Issue ref: https://github.com/meinaart/cypress-plugin-snapshots/issues/152