### PR TITLE
Update type definitions for `toMatchImageSnapshot`

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -18,10 +18,15 @@ declare namespace Cypress {
     }>): Chainable<null>;
 
     toMatchImageSnapshot(options?: Partial<{
-      createDiffImage: boolean,
-      threshold: number,
-      thresholdType: "percent" | "pixels",
-      name: string
-    }> & Partial<ScreenshotDefaultsOptions>): Chainable<null>;
+      imageConfig: Partial<{
+        createDiffImage: boolean,
+        threshold: number,
+        thresholdType: "percent" | "pixels",
+        resizeDevicePixelRatio: boolean
+      }>,
+      screenshotConfig: Partial<ScreenshotDefaultsOptions>,
+      name: string,
+      separator: string
+    }>): Chainable<null>;
   }
 }


### PR DESCRIPTION
Update options type def of `toMatchImageSnapshot`, based on https://github.com/meinaart/cypress-plugin-snapshots/issues/54