### PR TITLE
Update @jimp to v0.16.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -137,9 +137,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.9.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.6.tgz",
-      "integrity": "sha512-64AF1xY3OAkFHqOb9s4jpgk1Mm5vDZ4L3acHvAml+53nO1XbXLuDodsVpO4OIUsmemlUHMxNdYMNJmsvOwLrvQ==",
+      "version": "7.12.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
+      "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -387,26 +387,24 @@
       }
     },
     "@jimp/bmp": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@jimp/bmp/-/bmp-0.10.3.tgz",
-      "integrity": "sha512-keMOc5woiDmONXsB/6aXLR4Z5Q+v8lFq3EY2rcj2FmstbDMhRuGbmcBxlEgOqfRjwvtf/wOtJ3Of37oAWtVfLg==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@jimp/bmp/-/bmp-0.16.1.tgz",
+      "integrity": "sha512-iwyNYQeBawrdg/f24x3pQ5rEx+/GwjZcCXd3Kgc+ZUd+Ivia7sIqBsOnDaMZdKCBPlfW364ekexnlOqyVa0NWg==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.10.3",
-        "bmp-js": "^0.1.0",
-        "core-js": "^3.4.1"
+        "@jimp/utils": "^0.16.1",
+        "bmp-js": "^0.1.0"
       }
     },
     "@jimp/core": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@jimp/core/-/core-0.10.3.tgz",
-      "integrity": "sha512-Gd5IpL3U2bFIO57Fh/OA3HCpWm4uW/pU01E75rI03BXfTdz3T+J7TwvyG1XaqsQ7/DSlS99GXtLQPlfFIe28UA==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@jimp/core/-/core-0.16.1.tgz",
+      "integrity": "sha512-la7kQia31V6kQ4q1kI/uLimu8FXx7imWVajDGtwUG8fzePLWDFJyZl0fdIXVCL1JW2nBcRHidUot6jvlRDi2+g==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.10.3",
+        "@jimp/utils": "^0.16.1",
         "any-base": "^1.1.0",
         "buffer": "^5.2.0",
-        "core-js": "^3.4.1",
         "exif-parser": "^0.1.12",
         "file-type": "^9.0.0",
         "load-bmfont": "^1.3.1",
@@ -416,11 +414,6 @@
         "tinycolor2": "^1.4.1"
       },
       "dependencies": {
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
-        },
         "mkdirp": {
           "version": "0.5.5",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
@@ -432,323 +425,295 @@
       }
     },
     "@jimp/custom": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@jimp/custom/-/custom-0.10.3.tgz",
-      "integrity": "sha512-nZmSI+jwTi5IRyNLbKSXQovoeqsw+D0Jn0SxW08wYQvdkiWA8bTlDQFgQ7HVwCAKBm8oKkDB/ZEo9qvHJ+1gAQ==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@jimp/custom/-/custom-0.16.1.tgz",
+      "integrity": "sha512-DNUAHNSiUI/j9hmbatD6WN/EBIyeq4AO0frl5ETtt51VN1SvE4t4v83ZA/V6ikxEf3hxLju4tQ5Pc3zmZkN/3A==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/core": "^0.10.3",
-        "core-js": "^3.4.1"
+        "@jimp/core": "^0.16.1"
       }
     },
     "@jimp/gif": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@jimp/gif/-/gif-0.10.3.tgz",
-      "integrity": "sha512-vjlRodSfz1CrUvvrnUuD/DsLK1GHB/yDZXHthVdZu23zYJIW7/WrIiD1IgQ5wOMV7NocfrvPn2iqUfBP81/WWA==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@jimp/gif/-/gif-0.16.1.tgz",
+      "integrity": "sha512-r/1+GzIW1D5zrP4tNrfW+3y4vqD935WBXSc8X/wm23QTY9aJO9Lw6PEdzpYCEY+SOklIFKaJYUAq/Nvgm/9ryw==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.10.3",
-        "core-js": "^3.4.1",
+        "@jimp/utils": "^0.16.1",
+        "gifwrap": "^0.9.2",
         "omggif": "^1.0.9"
       }
     },
     "@jimp/jpeg": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@jimp/jpeg/-/jpeg-0.10.3.tgz",
-      "integrity": "sha512-AAANwgUZOt6f6P7LZxY9lyJ9xclqutYJlsxt3JbriXUGJgrrFAIkcKcqv1nObgmQASSAQKYaMV9KdHjMlWFKlQ==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@jimp/jpeg/-/jpeg-0.16.1.tgz",
+      "integrity": "sha512-8352zrdlCCLFdZ/J+JjBslDvml+fS3Z8gttdml0We759PnnZGqrnPRhkOEOJbNUlE+dD4ckLeIe6NPxlS/7U+w==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.10.3",
-        "core-js": "^3.4.1",
-        "jpeg-js": "^0.3.4"
+        "@jimp/utils": "^0.16.1",
+        "jpeg-js": "0.4.2"
       }
     },
     "@jimp/plugin-blit": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-0.10.3.tgz",
-      "integrity": "sha512-5zlKlCfx4JWw9qUVC7GI4DzXyxDWyFvgZLaoGFoT00mlXlN75SarlDwc9iZ/2e2kp4bJWxz3cGgG4G/WXrbg3Q==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-0.16.1.tgz",
+      "integrity": "sha512-fKFNARm32RoLSokJ8WZXHHH2CGzz6ire2n1Jh6u+XQLhk9TweT1DcLHIXwQMh8oR12KgjbgsMGvrMVlVknmOAg==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.10.3",
-        "core-js": "^3.4.1"
+        "@jimp/utils": "^0.16.1"
       }
     },
     "@jimp/plugin-blur": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-0.10.3.tgz",
-      "integrity": "sha512-cTOK3rjh1Yjh23jSfA6EHCHjsPJDEGLC8K2y9gM7dnTUK1y9NNmkFS23uHpyjgsWFIoH9oRh2SpEs3INjCpZhQ==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-0.16.1.tgz",
+      "integrity": "sha512-1WhuLGGj9MypFKRcPvmW45ht7nXkOKu+lg3n2VBzIB7r4kKNVchuI59bXaCYQumOLEqVK7JdB4glaDAbCQCLyw==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.10.3",
-        "core-js": "^3.4.1"
+        "@jimp/utils": "^0.16.1"
       }
     },
     "@jimp/plugin-circle": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-circle/-/plugin-circle-0.10.3.tgz",
-      "integrity": "sha512-51GAPIVelqAcfuUpaM5JWJ0iWl4vEjNXB7p4P7SX5udugK5bxXUjO6KA2qgWmdpHuCKtoNgkzWU9fNSuYp7tCA==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-circle/-/plugin-circle-0.16.1.tgz",
+      "integrity": "sha512-JK7yi1CIU7/XL8hdahjcbGA3V7c+F+Iw+mhMQhLEi7Q0tCnZ69YJBTamMiNg3fWPVfMuvWJJKOBRVpwNTuaZRg==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.10.3",
-        "core-js": "^3.4.1"
+        "@jimp/utils": "^0.16.1"
       }
     },
     "@jimp/plugin-color": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-0.10.3.tgz",
-      "integrity": "sha512-RgeHUElmlTH7vpI4WyQrz6u59spiKfVQbsG/XUzfWGamFSixa24ZDwX/yV/Ts+eNaz7pZeIuv533qmKPvw2ujg==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-0.16.1.tgz",
+      "integrity": "sha512-9yQttBAO5SEFj7S6nJK54f+1BnuBG4c28q+iyzm1JjtnehjqMg6Ljw4gCSDCvoCQ3jBSYHN66pmwTV74SU1B7A==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.10.3",
-        "core-js": "^3.4.1",
+        "@jimp/utils": "^0.16.1",
         "tinycolor2": "^1.4.1"
       }
     },
     "@jimp/plugin-contain": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-contain/-/plugin-contain-0.10.3.tgz",
-      "integrity": "sha512-bYJKW9dqzcB0Ihc6u7jSyKa3juStzbLs2LFr6fu8TzA2WkMS/R8h+ddkiO36+F9ILTWHP0CIA3HFe5OdOGcigw==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-contain/-/plugin-contain-0.16.1.tgz",
+      "integrity": "sha512-44F3dUIjBDHN+Ym/vEfg+jtjMjAqd2uw9nssN67/n4FdpuZUVs7E7wadKY1RRNuJO+WgcD5aDQcsvurXMETQTg==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.10.3",
-        "core-js": "^3.4.1"
+        "@jimp/utils": "^0.16.1"
       }
     },
     "@jimp/plugin-cover": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-cover/-/plugin-cover-0.10.3.tgz",
-      "integrity": "sha512-pOxu0cM0BRPzdV468n4dMocJXoMbTnARDY/EpC3ZW15SpMuc/dr1KhWQHgoQX5kVW1Wt8zgqREAJJCQ5KuPKDA==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-cover/-/plugin-cover-0.16.1.tgz",
+      "integrity": "sha512-YztWCIldBAVo0zxcQXR+a/uk3/TtYnpKU2CanOPJ7baIuDlWPsG+YE4xTsswZZc12H9Kl7CiziEbDtvF9kwA/Q==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.10.3",
-        "core-js": "^3.4.1"
+        "@jimp/utils": "^0.16.1"
       }
     },
     "@jimp/plugin-crop": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-0.10.3.tgz",
-      "integrity": "sha512-nB7HgOjjl9PgdHr076xZ3Sr6qHYzeBYBs9qvs3tfEEUeYMNnvzgCCGtUl6eMakazZFCMk3mhKmcB9zQuHFOvkg==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-0.16.1.tgz",
+      "integrity": "sha512-UQdva9oQzCVadkyo3T5Tv2CUZbf0klm2cD4cWMlASuTOYgaGaFHhT9st+kmfvXjKL8q3STkBu/zUPV6PbuV3ew==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.10.3",
-        "core-js": "^3.4.1"
+        "@jimp/utils": "^0.16.1"
       }
     },
     "@jimp/plugin-displace": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-displace/-/plugin-displace-0.10.3.tgz",
-      "integrity": "sha512-8t3fVKCH5IVqI4lewe4lFFjpxxr69SQCz5/tlpDLQZsrNScNJivHdQ09zljTrVTCSgeCqQJIKgH2Q7Sk/pAZ0w==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-displace/-/plugin-displace-0.16.1.tgz",
+      "integrity": "sha512-iVAWuz2+G6Heu8gVZksUz+4hQYpR4R0R/RtBzpWEl8ItBe7O6QjORAkhxzg+WdYLL2A/Yd4ekTpvK0/qW8hTVw==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.10.3",
-        "core-js": "^3.4.1"
+        "@jimp/utils": "^0.16.1"
       }
     },
     "@jimp/plugin-dither": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-dither/-/plugin-dither-0.10.3.tgz",
-      "integrity": "sha512-JCX/oNSnEg1kGQ8ffZ66bEgQOLCY3Rn+lrd6v1jjLy/mn9YVZTMsxLtGCXpiCDC2wG/KTmi4862ysmP9do9dAQ==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-dither/-/plugin-dither-0.16.1.tgz",
+      "integrity": "sha512-tADKVd+HDC9EhJRUDwMvzBXPz4GLoU6s5P7xkVq46tskExYSptgj5713J5Thj3NMgH9Rsqu22jNg1H/7tr3V9Q==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.10.3",
-        "core-js": "^3.4.1"
+        "@jimp/utils": "^0.16.1"
       }
     },
     "@jimp/plugin-fisheye": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-fisheye/-/plugin-fisheye-0.10.3.tgz",
-      "integrity": "sha512-RRZb1wqe+xdocGcFtj2xHU7sF7xmEZmIa6BmrfSchjyA2b32TGPWKnP3qyj7p6LWEsXn+19hRYbjfyzyebPElQ==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-fisheye/-/plugin-fisheye-0.16.1.tgz",
+      "integrity": "sha512-BWHnc5hVobviTyIRHhIy9VxI1ACf4CeSuCfURB6JZm87YuyvgQh5aX5UDKtOz/3haMHXBLP61ZBxlNpMD8CG4A==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.10.3",
-        "core-js": "^3.4.1"
+        "@jimp/utils": "^0.16.1"
       }
     },
     "@jimp/plugin-flip": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-flip/-/plugin-flip-0.10.3.tgz",
-      "integrity": "sha512-0epbi8XEzp0wmSjoW9IB0iMu0yNF17aZOxLdURCN3Zr+8nWPs5VNIMqSVa1Y62GSyiMDpVpKF/ITiXre+EqrPg==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-flip/-/plugin-flip-0.16.1.tgz",
+      "integrity": "sha512-KdxTf0zErfZ8DyHkImDTnQBuHby+a5YFdoKI/G3GpBl3qxLBvC+PWkS2F/iN3H7wszP7/TKxTEvWL927pypT0w==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.10.3",
-        "core-js": "^3.4.1"
+        "@jimp/utils": "^0.16.1"
       }
     },
     "@jimp/plugin-gaussian": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-gaussian/-/plugin-gaussian-0.10.3.tgz",
-      "integrity": "sha512-25eHlFbHUDnMMGpgRBBeQ2AMI4wsqCg46sue0KklI+c2BaZ+dGXmJA5uT8RTOrt64/K9Wz5E+2n7eBnny4dfpQ==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-gaussian/-/plugin-gaussian-0.16.1.tgz",
+      "integrity": "sha512-u9n4wjskh3N1mSqketbL6tVcLU2S5TEaFPR40K6TDv4phPLZALi1Of7reUmYpVm8mBDHt1I6kGhuCJiWvzfGyg==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.10.3",
-        "core-js": "^3.4.1"
+        "@jimp/utils": "^0.16.1"
       }
     },
     "@jimp/plugin-invert": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-invert/-/plugin-invert-0.10.3.tgz",
-      "integrity": "sha512-effYSApWY/FbtlzqsKXlTLkgloKUiHBKjkQnqh5RL4oQxh/33j6aX+HFdDyQKtsXb8CMd4xd7wyiD2YYabTa0g==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-invert/-/plugin-invert-0.16.1.tgz",
+      "integrity": "sha512-2DKuyVXANH8WDpW9NG+PYFbehzJfweZszFYyxcaewaPLN0GxvxVLOGOPP1NuUTcHkOdMFbE0nHDuB7f+sYF/2w==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.10.3",
-        "core-js": "^3.4.1"
+        "@jimp/utils": "^0.16.1"
       }
     },
     "@jimp/plugin-mask": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-mask/-/plugin-mask-0.10.3.tgz",
-      "integrity": "sha512-twrg8q8TIhM9Z6Jcu9/5f+OCAPaECb0eKrrbbIajJqJ3bCUlj5zbfgIhiQIzjPJ6KjpnFPSqHQfHkU1Vvk/nVw==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-mask/-/plugin-mask-0.16.1.tgz",
+      "integrity": "sha512-snfiqHlVuj4bSFS0v96vo2PpqCDMe4JB+O++sMo5jF5mvGcGL6AIeLo8cYqPNpdO6BZpBJ8MY5El0Veckhr39Q==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.10.3",
-        "core-js": "^3.4.1"
+        "@jimp/utils": "^0.16.1"
       }
     },
     "@jimp/plugin-normalize": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-normalize/-/plugin-normalize-0.10.3.tgz",
-      "integrity": "sha512-xkb5eZI/mMlbwKkDN79+1/t/+DBo8bBXZUMsT4gkFgMRKNRZ6NQPxlv1d3QpRzlocsl6UMxrHnhgnXdLAcgrXw==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-normalize/-/plugin-normalize-0.16.1.tgz",
+      "integrity": "sha512-dOQfIOvGLKDKXPU8xXWzaUeB0nvkosHw6Xg1WhS1Z5Q0PazByhaxOQkSKgUryNN/H+X7UdbDvlyh/yHf3ITRaw==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.10.3",
-        "core-js": "^3.4.1"
+        "@jimp/utils": "^0.16.1"
       }
     },
     "@jimp/plugin-print": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-print/-/plugin-print-0.10.3.tgz",
-      "integrity": "sha512-wjRiI6yjXsAgMe6kVjizP+RgleUCLkH256dskjoNvJzmzbEfO7xQw9g6M02VET+emnbY0CO83IkrGm2q43VRyg==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-print/-/plugin-print-0.16.1.tgz",
+      "integrity": "sha512-ceWgYN40jbN4cWRxixym+csyVymvrryuKBQ+zoIvN5iE6OyS+2d7Mn4zlNgumSczb9GGyZZESIgVcBDA1ezq0Q==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.10.3",
-        "core-js": "^3.4.1",
+        "@jimp/utils": "^0.16.1",
         "load-bmfont": "^1.4.0"
       }
     },
     "@jimp/plugin-resize": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-0.10.3.tgz",
-      "integrity": "sha512-rf8YmEB1d7Sg+g4LpqF0Mp+dfXfb6JFJkwlAIWPUOR7lGsPWALavEwTW91c0etEdnp0+JB9AFpy6zqq7Lwkq6w==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-0.16.1.tgz",
+      "integrity": "sha512-u4JBLdRI7dargC04p2Ha24kofQBk3vhaf0q8FwSYgnCRwxfvh2RxvhJZk9H7Q91JZp6wgjz/SjvEAYjGCEgAwQ==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.10.3",
-        "core-js": "^3.4.1"
+        "@jimp/utils": "^0.16.1"
       }
     },
     "@jimp/plugin-rotate": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-0.10.3.tgz",
-      "integrity": "sha512-YXLlRjm18fkW9MOHUaVAxWjvgZM851ofOipytz5FyKp4KZWDLk+dZK1JNmVmK7MyVmAzZ5jsgSLhIgj+GgN0Eg==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-0.16.1.tgz",
+      "integrity": "sha512-ZUU415gDQ0VjYutmVgAYYxC9Og9ixu2jAGMCU54mSMfuIlmohYfwARQmI7h4QB84M76c9hVLdONWjuo+rip/zg==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.10.3",
-        "core-js": "^3.4.1"
+        "@jimp/utils": "^0.16.1"
       }
     },
     "@jimp/plugin-scale": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-scale/-/plugin-scale-0.10.3.tgz",
-      "integrity": "sha512-5DXD7x7WVcX1gUgnlFXQa8F+Q3ThRYwJm+aesgrYvDOY+xzRoRSdQvhmdd4JEEue3lyX44DvBSgCIHPtGcEPaw==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-scale/-/plugin-scale-0.16.1.tgz",
+      "integrity": "sha512-jM2QlgThIDIc4rcyughD5O7sOYezxdafg/2Xtd1csfK3z6fba3asxDwthqPZAgitrLgiKBDp6XfzC07Y/CefUw==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.10.3",
-        "core-js": "^3.4.1"
+        "@jimp/utils": "^0.16.1"
       }
     },
     "@jimp/plugin-shadow": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-shadow/-/plugin-shadow-0.10.3.tgz",
-      "integrity": "sha512-/nkFXpt2zVcdP4ETdkAUL0fSzyrC5ZFxdcphbYBodqD7fXNqChS/Un1eD4xCXWEpW8cnG9dixZgQgStjywH0Mg==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-shadow/-/plugin-shadow-0.16.1.tgz",
+      "integrity": "sha512-MeD2Is17oKzXLnsphAa1sDstTu6nxscugxAEk3ji0GV1FohCvpHBcec0nAq6/czg4WzqfDts+fcPfC79qWmqrA==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.10.3",
-        "core-js": "^3.4.1"
+        "@jimp/utils": "^0.16.1"
       }
     },
     "@jimp/plugin-threshold": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-threshold/-/plugin-threshold-0.10.3.tgz",
-      "integrity": "sha512-Dzh0Yq2wXP2SOnxcbbiyA4LJ2luwrdf1MghNIt9H+NX7B+IWw/N8qA2GuSm9n4BPGSLluuhdAWJqHcTiREriVA==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-threshold/-/plugin-threshold-0.16.1.tgz",
+      "integrity": "sha512-iGW8U/wiCSR0+6syrPioVGoSzQFt4Z91SsCRbgNKTAk7D+XQv6OI78jvvYg4o0c2FOlwGhqz147HZV5utoSLxA==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.10.3",
-        "core-js": "^3.4.1"
+        "@jimp/utils": "^0.16.1"
       }
     },
     "@jimp/plugins": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@jimp/plugins/-/plugins-0.10.3.tgz",
-      "integrity": "sha512-jTT3/7hOScf0EIKiAXmxwayHhryhc1wWuIe3FrchjDjr9wgIGNN2a7XwCgPl3fML17DXK1x8EzDneCdh261bkw==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugins/-/plugins-0.16.1.tgz",
+      "integrity": "sha512-c+lCqa25b+4q6mJZSetlxhMoYuiltyS+ValLzdwK/47+aYsq+kcJNl+TuxIEKf59yr9+5rkbpsPkZHLF/V7FFA==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/plugin-blit": "^0.10.3",
-        "@jimp/plugin-blur": "^0.10.3",
-        "@jimp/plugin-circle": "^0.10.3",
-        "@jimp/plugin-color": "^0.10.3",
-        "@jimp/plugin-contain": "^0.10.3",
-        "@jimp/plugin-cover": "^0.10.3",
-        "@jimp/plugin-crop": "^0.10.3",
-        "@jimp/plugin-displace": "^0.10.3",
-        "@jimp/plugin-dither": "^0.10.3",
-        "@jimp/plugin-fisheye": "^0.10.3",
-        "@jimp/plugin-flip": "^0.10.3",
-        "@jimp/plugin-gaussian": "^0.10.3",
-        "@jimp/plugin-invert": "^0.10.3",
-        "@jimp/plugin-mask": "^0.10.3",
-        "@jimp/plugin-normalize": "^0.10.3",
-        "@jimp/plugin-print": "^0.10.3",
-        "@jimp/plugin-resize": "^0.10.3",
-        "@jimp/plugin-rotate": "^0.10.3",
-        "@jimp/plugin-scale": "^0.10.3",
-        "@jimp/plugin-shadow": "^0.10.3",
-        "@jimp/plugin-threshold": "^0.10.3",
-        "core-js": "^3.4.1",
+        "@jimp/plugin-blit": "^0.16.1",
+        "@jimp/plugin-blur": "^0.16.1",
+        "@jimp/plugin-circle": "^0.16.1",
+        "@jimp/plugin-color": "^0.16.1",
+        "@jimp/plugin-contain": "^0.16.1",
+        "@jimp/plugin-cover": "^0.16.1",
+        "@jimp/plugin-crop": "^0.16.1",
+        "@jimp/plugin-displace": "^0.16.1",
+        "@jimp/plugin-dither": "^0.16.1",
+        "@jimp/plugin-fisheye": "^0.16.1",
+        "@jimp/plugin-flip": "^0.16.1",
+        "@jimp/plugin-gaussian": "^0.16.1",
+        "@jimp/plugin-invert": "^0.16.1",
+        "@jimp/plugin-mask": "^0.16.1",
+        "@jimp/plugin-normalize": "^0.16.1",
+        "@jimp/plugin-print": "^0.16.1",
+        "@jimp/plugin-resize": "^0.16.1",
+        "@jimp/plugin-rotate": "^0.16.1",
+        "@jimp/plugin-scale": "^0.16.1",
+        "@jimp/plugin-shadow": "^0.16.1",
+        "@jimp/plugin-threshold": "^0.16.1",
         "timm": "^1.6.1"
       }
     },
     "@jimp/png": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@jimp/png/-/png-0.10.3.tgz",
-      "integrity": "sha512-YKqk/dkl+nGZxSYIDQrqhmaP8tC3IK8H7dFPnnzFVvbhDnyYunqBZZO3SaZUKTichClRw8k/CjBhbc+hifSGWg==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@jimp/png/-/png-0.16.1.tgz",
+      "integrity": "sha512-iyWoCxEBTW0OUWWn6SveD4LePW89kO7ZOy5sCfYeDM/oTPLpR8iMIGvZpZUz1b8kvzFr27vPst4E5rJhGjwsdw==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.10.3",
-        "core-js": "^3.4.1",
+        "@jimp/utils": "^0.16.1",
         "pngjs": "^3.3.3"
       }
     },
     "@jimp/tiff": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@jimp/tiff/-/tiff-0.10.3.tgz",
-      "integrity": "sha512-7EsJzZ5Y/EtinkBGuwX3Bi4S+zgbKouxjt9c82VJTRJOQgLWsE/RHqcyRCOQBhHAZ9QexYmDz34medfLKdoX0g==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@jimp/tiff/-/tiff-0.16.1.tgz",
+      "integrity": "sha512-3K3+xpJS79RmSkAvFMgqY5dhSB+/sxhwTFA9f4AVHUK0oKW+u6r52Z1L0tMXHnpbAdR9EJ+xaAl2D4x19XShkQ==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "core-js": "^3.4.1",
         "utif": "^2.0.1"
       }
     },
     "@jimp/types": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@jimp/types/-/types-0.10.3.tgz",
-      "integrity": "sha512-XGmBakiHZqseSWr/puGN+CHzx0IKBSpsKlmEmsNV96HKDiP6eu8NSnwdGCEq2mmIHe0JNcg1hqg59hpwtQ7Tiw==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@jimp/types/-/types-0.16.1.tgz",
+      "integrity": "sha512-g1w/+NfWqiVW4CaXSJyD28JQqZtm2eyKMWPhBBDCJN9nLCN12/Az0WFF3JUAktzdsEC2KRN2AqB1a2oMZBNgSQ==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/bmp": "^0.10.3",
-        "@jimp/gif": "^0.10.3",
-        "@jimp/jpeg": "^0.10.3",
-        "@jimp/png": "^0.10.3",
-        "@jimp/tiff": "^0.10.3",
-        "core-js": "^3.4.1",
+        "@jimp/bmp": "^0.16.1",
+        "@jimp/gif": "^0.16.1",
+        "@jimp/jpeg": "^0.16.1",
+        "@jimp/png": "^0.16.1",
+        "@jimp/tiff": "^0.16.1",
         "timm": "^1.6.1"
       }
     },
     "@jimp/utils": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.10.3.tgz",
-      "integrity": "sha512-VcSlQhkil4ReYmg1KkN+WqHyYfZ2XfZxDsKAHSfST1GEz/RQHxKZbX+KhFKtKflnL0F4e6DlNQj3vznMNXCR2w==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.16.1.tgz",
+      "integrity": "sha512-8fULQjB0x4LzUSiSYG6ZtQl355sZjxbv8r9PPAuYHzS9sGiSHJQavNqK/nKnpDsVkU88/vRGcE7t3nMU0dEnVw==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "core-js": "^3.4.1",
         "regenerator-runtime": "^0.13.3"
       }
     },
@@ -1312,9 +1277,9 @@
       "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg="
     },
     "base64-js": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
     "base64id": {
       "version": "1.0.0",
@@ -1419,12 +1384,12 @@
       }
     },
     "buffer": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
-      "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
       "requires": {
-        "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4"
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "buffer-equal": {
@@ -1712,11 +1677,6 @@
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
-    },
-    "core-js": {
-      "version": "3.6.5",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
-      "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -3318,6 +3278,15 @@
         "assert-plus": "^1.0.0"
       }
     },
+    "gifwrap": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/gifwrap/-/gifwrap-0.9.2.tgz",
+      "integrity": "sha512-fcIswrPaiCDAyO8xnWvHSZdWChjKXUanKKpAiWWJ/UTkEi/aYKn5+90e7DE820zbEaVR9CE2y4z9bzhQijZ0BA==",
+      "requires": {
+        "image-q": "^1.1.1",
+        "omggif": "^1.0.10"
+      }
+    },
     "glob": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
@@ -3507,15 +3476,20 @@
       }
     },
     "ieee754": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
     "ignore": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
       "dev": true
+    },
+    "image-q": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/image-q/-/image-q-1.1.1.tgz",
+      "integrity": "sha1-/IQJlmRGC5DKhi2TALa/u7+/gFY="
     },
     "image-size": {
       "version": "0.7.4",
@@ -4425,22 +4399,21 @@
       }
     },
     "jimp": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/jimp/-/jimp-0.10.3.tgz",
-      "integrity": "sha512-meVWmDMtyUG5uYjFkmzu0zBgnCvvxwWNi27c4cg55vWNVC9ES4Lcwb+ogx+uBBQE3Q+dLKjXaLl0JVW+nUNwbQ==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/jimp/-/jimp-0.16.1.tgz",
+      "integrity": "sha512-+EKVxbR36Td7Hfd23wKGIeEyHbxShZDX6L8uJkgVW3ESA9GiTEPK08tG1XI2r/0w5Ch0HyJF5kPqF9K7EmGjaw==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/custom": "^0.10.3",
-        "@jimp/plugins": "^0.10.3",
-        "@jimp/types": "^0.10.3",
-        "core-js": "^3.4.1",
+        "@jimp/custom": "^0.16.1",
+        "@jimp/plugins": "^0.16.1",
+        "@jimp/types": "^0.16.1",
         "regenerator-runtime": "^0.13.3"
       }
     },
     "jpeg-js": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.3.7.tgz",
-      "integrity": "sha512-9IXdWudL61npZjvLuVe/ktHiA41iE8qFyLB+4VDTblEsWBzeg8WQTlktdUK4CdncUqtUgUg0bbOmTE2bKBKaBQ=="
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.2.tgz",
+      "integrity": "sha512-+az2gi/hvex7eLTMTlbRLOhH6P6WFdk2ITI8HJsaH2VqYO0I594zXSYEP+tf4FW+8Cy68ScDXoAsQdyQanv3sw=="
     },
     "js-base64": {
       "version": "2.5.1",
@@ -4628,9 +4601,9 @@
       }
     },
     "load-bmfont": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/load-bmfont/-/load-bmfont-1.4.0.tgz",
-      "integrity": "sha512-kT63aTAlNhZARowaNYcY29Fn/QYkc52M3l6V1ifRcPewg2lvUZDAj7R6dXjOL9D0sict76op3T5+odumDSF81g==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/load-bmfont/-/load-bmfont-1.4.1.tgz",
+      "integrity": "sha512-8UyQoYmdRDy81Brz6aLAUhfZLwr5zV0L3taTQ4hju7m6biuwiWiJXjPhBJxbUQJA8PrkvJ/7Enqmwk2sM14soA==",
       "requires": {
         "buffer-equal": "0.0.1",
         "mime": "^1.3.4",
@@ -4813,6 +4786,11 @@
       "requires": {
         "brace-expansion": "^1.1.7"
       }
+    },
+    "minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mixin-deep": {
       "version": "1.3.2",
@@ -5505,9 +5483,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.5",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
     },
     "regex-not": {
       "version": "1.0.2",
@@ -6770,14 +6748,14 @@
       "dev": true
     },
     "timm": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/timm/-/timm-1.6.2.tgz",
-      "integrity": "sha512-IH3DYDL1wMUwmIlVmMrmesw5lZD6N+ZOAFWEyLrtpoL9Bcrs9u7M/vyOnHzDD2SMs4irLkVjqxZbHrXStS/Nmw=="
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/timm/-/timm-1.7.1.tgz",
+      "integrity": "sha512-IjZc9KIotudix8bMaBW6QvMuq64BrJWFs1+4V0lXwWGQZwH+LnX87doAYhem4caOEusRP9/g6jVDQmZ8XOk1nw=="
     },
     "tinycolor2": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.1.tgz",
-      "integrity": "sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g="
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.2.tgz",
+      "integrity": "sha512-vJhccZPs965sV/L2sU4oRQVAos0pQXwsvTLkWYdqJ+a8Q5kPFzJTuOFwy7UniPli44NKQGAglksjvOcpo95aZA=="
     },
     "tmp": {
       "version": "0.0.33",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "diff2html": "^2.7.0",
     "fs-extra": "^7.0.1",
     "image-size": "^0.7.2",
-    "jimp": "^0.10.3",
+    "jimp": "^0.16.1",
     "js-base64": "^2.5.1",
     "lodash": "^4.17.13",
     "pixelmatch": "^4.0.2",


### PR DESCRIPTION
### Description
One of the dependencies `@jimp` has a dependency to `jpeg-js` that is triggering the dependency warning [Uncontrolled resource consumption in jpeg-js](https://github.com/advisories/GHSA-w7q9-p3jq-fmhm). It is moderate severity so I'd love to update `@jimp` to the latest version so that we have the patched version of `jpeg-js`.