### PR TITLE
Fix failure handling in spec retry

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -48,11 +48,15 @@ function initCommands() {
     Cypress.__readFileCache__ = {};
   }
 
+  // Reset snapshot counters before each test run to account for retries
+  Cypress.on('test:before:run', () => {
+    resetSnapshotCounts();
+  });
+
   // Close snapshot modal and reset image files cache before all test restart
   Cypress.on('window:before:unload', () => {
     closeSnapshotModal()
     clearFileCache()
-    resetSnapshotCounts()
   });
 
   // Clean up unused snapshots

--- a/commands.js
+++ b/commands.js
@@ -9,6 +9,7 @@ const commands = require('./src/commands/index');
 const cleanUpSnapshots = require('./src/utils/commands/cleanupSnapshots');
 const getConfig = require('./src/utils/commands/getConfig');
 const { NO_LOG } = require('./src/constants');
+const { resetSnapshotCounts } = require('./src/utils/snapshotTitles');
 
 function addCommand(commandName, method) {
   Cypress.Commands.add(commandName, {
@@ -51,6 +52,7 @@ function initCommands() {
   Cypress.on('window:before:unload', () => {
     closeSnapshotModal()
     clearFileCache()
+    resetSnapshotCounts()
   });
 
   // Clean up unused snapshots

--- a/src/tasks/matchImageSnapshot.js
+++ b/src/tasks/matchImageSnapshot.js
@@ -49,7 +49,7 @@ async function matchImageSnapshot(data = {}) {
 
   let updated = false;
 
-  if ((config.updateSnapshots && !passed) || expected === false) {
+  if ((config.updateSnapshots && !passed) || autoPassed) {
     saveImageSnapshot({ testFile, snapshotTitle, actual });
     updated = true;
   }

--- a/src/tasks/matchTextSnapshot.js
+++ b/src/tasks/matchTextSnapshot.js
@@ -38,7 +38,7 @@ function matchTextSnapshot({
 
   let updated = false;
 
-  if ((config.updateSnapshots && !passed) || expected === false) {
+  if ((config.updateSnapshots && !passed) || autoPassed) {
     updateSnapshot(snapshotFile, snapshotTitle, actual, dataType);
     updated = true;
   }

--- a/src/utils/snapshotTitles.js
+++ b/src/utils/snapshotTitles.js
@@ -3,8 +3,8 @@ const getTestTitle = require('./getTestTitle');
 let SNAPSHOTS_TEXT = {}
 let SNAPSHOTS_IMAGE = {};
 
-let SNAPSHOT_TITLES_TEXT = [];
-let SNAPSHOT_TITLES_IMAGE = [];
+const SNAPSHOT_TITLES_TEXT = [];
+const SNAPSHOT_TITLES_IMAGE = [];
 
 function snapshotTitleIsUsed(snapshotTitle, isImage = false) {
   return (isImage ? SNAPSHOT_TITLES_IMAGE : SNAPSHOT_TITLES_TEXT).indexOf(snapshotTitle) !== -1;
@@ -27,10 +27,9 @@ function getSnapshotTitle(test, customName, customSeparator, isImage = false) {
 }
 
 function resetSnapshotCounts() {
+  // Only reset counters. Assume that the titles used will be consistent and fine with dupes.
   SNAPSHOTS_TEXT = {};
   SNAPSHOTS_IMAGE = {};
-  SNAPSHOT_TITLES_TEXT = [];
-  SNAPSHOT_TITLES_IMAGE = [];
 }
 
 module.exports = {

--- a/src/utils/snapshotTitles.js
+++ b/src/utils/snapshotTitles.js
@@ -1,10 +1,10 @@
 const getTestTitle = require('./getTestTitle');
 
-const SNAPSHOTS_TEXT = {}
-const SNAPSHOTS_IMAGE = {};
+let SNAPSHOTS_TEXT = {}
+let SNAPSHOTS_IMAGE = {};
 
-const SNAPSHOT_TITLES_TEXT = [];
-const SNAPSHOT_TITLES_IMAGE = [];
+let SNAPSHOT_TITLES_TEXT = [];
+let SNAPSHOT_TITLES_IMAGE = [];
 
 function snapshotTitleIsUsed(snapshotTitle, isImage = false) {
   return (isImage ? SNAPSHOT_TITLES_IMAGE : SNAPSHOT_TITLES_TEXT).indexOf(snapshotTitle) !== -1;
@@ -26,7 +26,15 @@ function getSnapshotTitle(test, customName, customSeparator, isImage = false) {
   return snapshotTitle;
 }
 
+function resetSnapshotCounts() {
+  SNAPSHOTS_TEXT = {};
+  SNAPSHOTS_IMAGE = {};
+  SNAPSHOT_TITLES_TEXT = [];
+  SNAPSHOT_TITLES_IMAGE = [];
+}
+
 module.exports = {
   getSnapshotTitle,
-  snapshotTitleIsUsed
+  snapshotTitleIsUsed,
+  resetSnapshotCounts
 }

--- a/src/utils/tasks/textSnapshots.js
+++ b/src/utils/tasks/textSnapshots.js
@@ -63,8 +63,6 @@ function getSnapshot(filename, snapshotTitle, dataType = TYPE_JSON) {
     if (snapshots[snapshotTitle]) {
       return subjectToSnapshot(snapshots[snapshotTitle], dataType);
     }
-  } else {
-    fs.writeFileSync(filename, '{}');
   }
 
   return false;


### PR DESCRIPTION
When running in retry mode with a failing snapshot, we would see the expected failure on the first attempt. On the second attempt this would pass as the numeric ID for the snapshot was incremented, creating a new snapshot.

This PR changes behavior so that
- Snapshots are not written if autopassNewSnapshots is false
- Snapshot id trackers are reset after test completion