### PR TITLE
chore: update diff2html

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "test": "jest & npm --prefix cypress run cy:run"
   },
   "dependencies": {
-    "diff2html": "^2.7.0",
+    "diff2html": "^3.4.5",
     "fs-extra": "^7.0.1",
     "image-size": "^0.7.2",
     "jimp": "^0.16.1",


### PR DESCRIPTION
Should fix a security issue where `merge` is vulnerable to Prototype Pollution via _recursiveMerge. `diff2html` does no longer depend on the vulnerable package.