### PR TITLE
Add missing screenshot configuration options

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -81,7 +81,7 @@ function getImageConfig(options = {}) {
 
 
 function getScreenshotConfig(options = {}) {
-  const screenshotConfig = Object.keys(DEFAULT_SCREENSHOT_CONFIG)
+  const screenshotConfig = [...Object.keys(DEFAULT_SCREENSHOT_CONFIG), 'onAfterScreenshot', 'onBeforeScreenshot']
     .filter((key) => options.screenshotConfig && options.screenshotConfig[key] !== undefined)
     .reduce(
       (currentConfig, key) => {


### PR DESCRIPTION
You're filtering the available options by the keys you provide, however the `onAfterScreenshot` and `onBeforeScreenshot` keys are missing from the default object. Since we don't need to have them as a default of `null` or `() => {}`, I just added the keys to the array when choosing which keys we can use in the config options.