### PR TITLE
Fix cypress peer dependency to includ version higher than 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "unidiff": "1.0.2"
   },
   "peerDependencies": {
-    "cypress": "^4.5.0"
+    "cypress": ">=4.5.0"
   },
   "devDependencies": {
     "eslint": "^5.14.1",


### PR DESCRIPTION
Fixes #183 