### PR TITLE
ci: fix ubuntu runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on: [push]
 
 jobs:
   test:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     # Cypress Docker image with Chrome v78
     # and Firefox v70 pre-installed
     container: cypress/browsers:node12.13.0-chrome78-ff70

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
+.idea
 node_modules
 /cypress/cypress/screenshots


### PR DESCRIPTION
Current ubuntu version will be removed in September https://github.com/actions/virtual-environments/issues/3287.
Aligned with the version used in the publish workflow