### PR TITLE
#131: Fix issue with compare modal not opening in GUI.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 .DS_Store
 node_modules
 /cypress/cypress/screenshots


### PR DESCRIPTION
`cy.readFile` is a function to register a command on the cypress command loop. This command loop does not run while tests are not running. Thus the promise generate by `cy.readFile` will never resolve when called outside of an executing test. The solution is to bypass the command loop and call directly the underlying api.